### PR TITLE
Add ability to deploy the plug-in to emuStudio repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
     </dependencies>
     
     <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>2.2</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -58,4 +65,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <netbeans.hint.license>gpl20</netbeans.hint.license>
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>emustudio-repository</id>
+            <name>emuStudio Repository</name>
+            <url>sftp://web.sourceforge.net:/home/project-web/emustudio/htdocs/repository</url>
+        </repository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
The plug-in should be available in emuStudio repository in order to be able to compile CPUs without needing to compile the plugin first.
